### PR TITLE
Change user-agent to get UTF-8 encoded response

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,7 @@
-var jsonp = require('smol-jsonp')
+const jsonp = require('smol-jsonp')
 
 // `client` is a required parameter. `client=firefox` returns the smallest result.
-var baseUrl = 'https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q='
+const baseUrl = 'https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q='
 
 function unwrapResults (data) { return data[1] }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-var fetch = require('node-fetch')
+let fetch = require('node-fetch')
 if (typeof fetch !== 'function') fetch = window.fetch
 
 // `client` is a required parameter. `client=firefox` returns the smallest result.
-var baseUrl = 'https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q='
+const baseUrl = 'https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q='
 const headers = { 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0' }
 
 function parseJson (res) { return res.json() }

--- a/index.js
+++ b/index.js
@@ -3,12 +3,13 @@ if (typeof fetch !== 'function') fetch = window.fetch
 
 // `client` is a required parameter. `client=firefox` returns the smallest result.
 var baseUrl = 'https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q='
+const headers = { 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0' }
 
 function parseJson (res) { return res.json() }
 function unwrapResults (data) { return data[1] }
 
 function youtubeSuggest (query) {
-  return fetch(baseUrl + encodeURIComponent(query))
+  return fetch(baseUrl + encodeURIComponent(query), { headers })
     .then(parseJson)
     .then(unwrapResults)
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-var youtubeSuggest = require('.')
-var assert = require('assert')
+const youtubeSuggest = require('.')
+const assert = require('assert')
 
 youtubeSuggest('query').then(function (results) {
   assert(Array.isArray(results))


### PR DESCRIPTION
Related to FreeTubeApp/FreeTube#679

At the moment, the fetched JSON response is encoded in ISO-8859-1 for several user agents (including node-fetch).
This is problematic if the query is composed of certain special characters (such as characters with an umlaut -> `ö`)
Example (query = `ö`):
![image](https://user-images.githubusercontent.com/41585298/112737343-d0045580-8f51-11eb-9966-155f605f046c.png)

There are multiple ways to resolve this problem, but I chose this one for its simplicity.
The other solutions would be:
- changing the `client` query parameter to `youtube` makes it so the response is UTF-8 encoded (although more parsing work would be necessary 👎)
- using an encoding conversion lib, such as `iconv-lite` (would increase the size of the package and is only necessary in `index.js`, not `browser.js` 👎)

Result
![image](https://user-images.githubusercontent.com/41585298/112737374-05a93e80-8f52-11eb-9a2a-bb1f79d074ac.png)